### PR TITLE
Prevent uploading prebuilt binaries to NPM

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .travis.yml
 appveyor.yml
+build
 test.bat


### PR DESCRIPTION
Fixes issue where prebuilt binaries are uploaded to NPM, causing the module to become unusable for anyone whose architecture doesn't match the prebuilt binary.