### PR TITLE
Use console.error instead of console.dir

### DIFF
--- a/ext/index.js
+++ b/ext/index.js
@@ -14,7 +14,7 @@ try {
 	try {
 		bson = require('../build/Release/bson');
 	} catch (err) {
-		console.dir(err)
+		console.error(err)
 		console.error("js-bson: Failed to load c++ bson extension, using pure JS version");
 		throw new Error("js-bson: Failed to load c++ bson extension, using pure JS version");
 	}


### PR DESCRIPTION
In the event the native module cannot be loaded, use console.error
instead of console.dir so the error gets prints to stderr instead of
stdout.