### PR TITLE
Node 6 and windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "0.12"
   - "4"
   - "5"
+  - "6"
 sudo: false
 env:
   - CXX=g++-4.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+version: 0.0.{build}
+environment:
+  matrix:
+    - nodejs_version: "0.10"
+    - nodejs_version: "0.12"
+    - nodejs_version: "4"
+    - nodejs_version: "5"
+os:
+  - Visual Studio 2013
+  - Visual Studio 2015
+install:
+  - ps: Install-Product node $env:nodejs_version x64
+  # Sets Windows 7.1 SDK env vars.
+  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
+  # Prepend 2015 and 2013 tools. Harmless when the path for the other version doesn't exist.
+  - set "PATH=%ProgramFiles(x86)%\MSBuild\14.0\Bin;%ProgramFiles(x86)%\MSBuild\12.0\Bin;%PATH%"
+  # Upgrade npm to latest
+  - npm install --loglevel error -g npm
+  - set "PATH=%APPDATA%\npm;%PATH%"
+  - node -v
+  - npm -v
+  - npm install -g --loglevel error node-gyp
+  - npm install
+build: off
+test_script:
+  - cmd: npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
     - nodejs_version: "0.12"
     - nodejs_version: "4"
     - nodejs_version: "5"
+    - nodejs_version: "6"
 os:
   - Visual Studio 2013
   - Visual Studio 2015

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "bson",
     "parser"
   ],
-  "version": "0.1.13",
+  "version": "0.1.14",
   "author": "Christian Amor Kvalheim <christkv@gmail.com>",
   "contributors": [],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "nan": "~2.0.9"
+    "nan": "~2.3.5"
   },
   "devDependencies": {
     "nodeunit": "~0.9.0"


### PR DESCRIPTION
A few simple changes to 
* support node 6 (upgrade to nan 2.3.5). Should fix #28.
* support windows (use the windows compiler intrinsics for bswap). This was broken by #29 :cry:
* get rid of compiler warnings (fix types)